### PR TITLE
Enable passing in string tuple

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,2 +1,2 @@
-declare const browserslistToEsbuild: (browserslistConfig?: string[] | string) => string[]
+declare const browserslistToEsbuild: (browserslistConfig?: readonly string[] | string) => string[]
 export default browserslistToEsbuild


### PR DESCRIPTION
This change should be backwards compatible and at the same time allows passing string tuple

See this TS playground
https://www.typescriptlang.org/play?#code/MYewdgzgLgBArmAtnKBDARgGwKYwLwwDaARFNqsQDQzGgBmd22xAujKhDKJFAFC-do8JCgw4AylABOASzABzfDUSoowABYV+g2MjRZcBEmQrVaIBk1b8cu0QcmyFS4irWbi28ELoJgSgApUKXkALhhoJ3lCNgAfCOk5eQBKfAA+dhD+XzBgAIQ9MWxk3hy8woMSsvyRfQlEhSq-AIr6qJKBb1gZRAAHKRAAN2wAEwAxP0DgsJgpchHwTABPBKiYmHjIpNS8DOn+Hv6h0Yncmtbi3kOB4fHmi5Lr47uzgvs27au+m5P79+xHNsgA