### PR TITLE
Add IE and Opera target support, and Samsung Browser -> Chrome mapping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,34 @@
 const browserslist = require('browserslist')
+/*
+ * Values taken from https://en.wikipedia.org/wiki/Samsung_Internet#History
+ * and cross-referenced with https://browsersl.ist/#q=samsung+%3E+0 to get all
+ * samsung versions returned by browserslist.
+ *
+ * Not perfect by any means, but better than no samsung internet support at all.
+ *
+ * May be worth requesting a Samsung Internet target in esbuild, since Samsung Internet
+ * seems to be diverging from Chromium in terms of features, so this mapping isn't
+ * 100% accurate after a certain point.
+ */
+const samsungVersionMap = new Map([
+  ['4', '44'],
+  ['5.0-5.4', '51'],
+  ['6.2-6.4', '56'],
+  ['7.2-7.4', '59'],
+  ['8.2', '63'],
+  ['9.2', '67'],
+  ['10.1', '71'],
+  ['11.1-11.2', '75'],
+  ['12.0', '79'],
+  ['13.0', '83'],
+  ['14.0', '87'],
+  ['15.0', '90'],
+  ['16.0', '92'],
+  ['17.0', '96'],
+  ['18.0', '99'],
+  ['19.0', '102'],
+  ['20.0', '106'],
+])
 
 // convert the browserslist field in package.json to
 // esbuild compatible array of browsers
@@ -45,6 +75,11 @@ function browserslistToEsbuild(browserslistConfig) {
           b[0] = replaces[b[0]]
         }
 
+        if (b[0] === 'samsung') {
+          b[0] = 'chrome'
+          b[1] = samsungVersionMap.get(b[1])
+        }
+
         return b
       })
       // 11.0-12.0 --> 11.0
@@ -69,11 +104,15 @@ function browserslistToEsbuild(browserslistConfig) {
       .reduce((acc, b) => {
         const existingIndex = acc.findIndex((br) => br[0] === b[0])
 
-        if (existingIndex !== -1) {
-          acc[existingIndex][1] = b[1]
-        } else {
+        if (existingIndex === -1) {
           acc.push(b)
+          return acc
         }
+
+        if (Number.parseFloat(acc[existingIndex][1]) > Number.parseFloat(b[1])) {
+          acc[existingIndex][1] = b[1]
+        }
+
         return acc
       }, [])
       // remove separator

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,17 @@ function browserslistToEsbuild(browserslistConfig) {
     browserslistConfig = browserslist.loadConfig({ path })
   }
 
-  const SUPPORTED_ESBUILD_TARGETS = ['es', 'chrome', 'edge', 'firefox', 'ios', 'node', 'safari']
+  const SUPPORTED_ESBUILD_TARGETS = [
+    'es',
+    'chrome',
+    'edge',
+    'firefox',
+    'ios',
+    'node',
+    'safari',
+    'opera',
+    'ie',
+  ]
 
   // https://github.com/eBay/browserslist-config/issues/16#issuecomment-863870093
   const UNSUPPORTED = ['android 4']

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ test('works by passing browsers as string', (t) => {
   const target = browserslistToEsbuild('last 2 versions')
 
   t.deepEqual(target, [
-    'chrome93',
+    'chrome87',
     'edge93',
     'firefox92',
     'ie10',

--- a/test/test.js
+++ b/test/test.js
@@ -5,13 +5,29 @@ const browserslistToEsbuild = require('../src/index.js')
 test('works by passing browsers as array', (t) => {
   const target = browserslistToEsbuild(['>0.2%', 'not dead', 'not op_mini all'])
 
-  t.deepEqual(target, ['chrome79', 'edge92', 'firefox91', 'ios12.2', 'safari13.1'])
+  t.deepEqual(target, [
+    'chrome79',
+    'edge92',
+    'firefox91',
+    'ie11',
+    'ios12.2',
+    'opera78',
+    'safari13.1',
+  ])
 })
 
 test('works by passing browsers as string', (t) => {
   const target = browserslistToEsbuild('last 2 versions')
 
-  t.deepEqual(target, ['chrome93', 'edge93', 'firefox92', 'ios14.5', 'safari14.1'])
+  t.deepEqual(target, [
+    'chrome93',
+    'edge93',
+    'firefox92',
+    'ie10',
+    'ios14.5',
+    'opera79',
+    'safari14.1',
+  ])
 })
 
 test('works by loading package.json config', (t) => {
@@ -20,7 +36,15 @@ test('works by loading package.json config', (t) => {
   process.chdir(packageJsonDir) // makes process.cwd() go in that folder
 
   process.env.NODE_ENV = 'production'
-  t.deepEqual(browserslistToEsbuild(), ['chrome79', 'edge92', 'firefox91', 'ios12.2', 'safari13.1'])
+  t.deepEqual(browserslistToEsbuild(), [
+    'chrome79',
+    'edge92',
+    'firefox91',
+    'ie11',
+    'ios12.2',
+    'opera78',
+    'safari13.1',
+  ])
 
   process.env.NODE_ENV = 'development'
   t.deepEqual(browserslistToEsbuild(), ['chrome94', 'firefox93', 'safari15'])


### PR DESCRIPTION
The latest 2 versions for browserslist@4.17.3 are 14 and 15, which is why I had to update the test value for chrome.

The logic for `select lowest` was broken by samsung internet, since the mapping made chrome entries appear after the rest of chrome (i.e. 
```js
[
  ["chrome": "93", ..., "chrome": "79"],
  ...,
  ["ie": "11", "ie": "10"],
  ...,
  ["chrome": "87", ...], // Samsung Internet, mapped to Chrome
  ...
]
```
)