### PR TITLE
Fix for determining Desktop Safari version, improve code readability

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ export default function browserslistToEsbuild(browserslistConfig, options = {}) 
     browserslistConfig = browserslist.loadConfig({ path, ...options })
   }
 
-  const SUPPORTED_ESBUILD_TARGETS = [
+  const SUPPORTED_ESBUILD_TARGETS = new Set([
     'es',
     'chrome',
     'edge',
@@ -21,7 +21,7 @@ export default function browserslistToEsbuild(browserslistConfig, options = {}) 
     'safari',
     'opera',
     'ie',
-  ]
+  ])
 
   // https://github.com/eBay/browserslist-config/issues/16#issuecomment-863870093
   const UNSUPPORTED = ['android 4']
@@ -33,62 +33,33 @@ export default function browserslistToEsbuild(browserslistConfig, options = {}) 
 
   const separator = ' '
 
-  return (
-    browserslist(browserslistConfig, options)
-      // filter out the unsupported ones
-      .filter((b) => !UNSUPPORTED.some((u) => b.startsWith(u)))
-      // replaces safari TP with latest safari version
-      .map((b) => {
-        if (b === 'safari TP') {
-          return browserslist('last 1 safari version')[0]
-        }
+  let listOfBrowsers = browserslist(browserslistConfig, options)
+    // filter out the unsupported ones
+    .filter(
+      (browser) => !UNSUPPORTED.some((unsupportedBrowser) => browser.startsWith(unsupportedBrowser))
+    )
+    // transform into ['chrome', '88']
+    .map((browser) => browser.split(separator))
+    // replace the similar browser
+    .map(([browserName, version]) => [replaces[browserName] || browserName, version])
+    // 11.0-12.0 --> 11.0
+    .map(([browserName, version]) => [
+      browserName,
+      version.includes('-') ? version.slice(0, version.indexOf('-')) : version,
+    ])
+    // 11.0 --> 11
+    .map(([browserName, version]) => [
+      browserName,
+      version.endsWith('.0') ? version.slice(0, -2) : version,
+    ])
+    // removes invalid versions that will break esbuild
+    // https://github.com/evanw/esbuild/blob/35c0d65b9d4f29a26176404d2890d1b499634e9f/compat-table/src/caniuse.ts#L119-L122
+    .filter(([, version]) => /^\d+(\.\d+)*$/.test(version))
+    // only get the targets supported by esbuild
+    .filter(([browserName]) => SUPPORTED_ESBUILD_TARGETS.has(browserName))
 
-        return b
-      })
-      // transform into ['chrome', '88']
-      .map((b) => b.split(separator))
-      // replace the similar browser
-      .map((b) => {
-        if (replaces[b[0]]) {
-          b[0] = replaces[b[0]]
-        }
+  // only get the oldest version, assuming that the older version is the last one in the array:
+  listOfBrowsers = Object.entries(Object.fromEntries(listOfBrowsers))
 
-        return b
-      })
-      // 11.0-12.0 --> 11.0
-      .map((b) => {
-        if (b[1].includes('-')) {
-          b[1] = b[1].slice(0, b[1].indexOf('-'))
-        }
-
-        return b
-      })
-      // 11.0 --> 11
-      .map((b) => {
-        if (b[1].endsWith('.0')) {
-          b[1] = b[1].slice(0, -2)
-        }
-
-        return b
-      })
-      // removes invalid versions that will break esbuild
-      // https://github.com/evanw/esbuild/blob/35c0d65b9d4f29a26176404d2890d1b499634e9f/compat-table/src/caniuse.ts#L119-L122
-      .filter((b) => /^\d+(\.\d+)*$/.test(b[1]))
-      // only get the targets supported by esbuild
-      .filter((b) => SUPPORTED_ESBUILD_TARGETS.includes(b[0]))
-      // only get the oldest version, assuming that the older version
-      // is last in the array
-      .reduce((acc, b) => {
-        const existingIndex = acc.findIndex((br) => br[0] === b[0])
-
-        if (existingIndex !== -1) {
-          acc[existingIndex][1] = b[1]
-        } else {
-          acc.push(b)
-        }
-        return acc
-      }, [])
-      // remove separator
-      .map((b) => b.join(''))
-  )
+  return listOfBrowsers.map(([browserName, version]) => `${browserName}${version}`)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -101,9 +101,3 @@ test('no support for android 4', (t) => {
 
   t.deepEqual(target, ['chrome120'])
 })
-
-test('safari TP defaults to latest safari', (t) => {
-  const target = browserslistToEsbuild('safari TP')
-
-  t.deepEqual(target, ['safari17.2'])
-})


### PR DESCRIPTION
Running `npx browserslist-to-esbuild 'supports css-grid'` results in `chrome57 edge12 firefox52 ie10 ios10.3 opera44 safari17.3`.
The desktop Safari version should be 10.1. See https://browsersl.ist/#q=supports+css-grid.

The source of the bug is the assumption at [this line](https://github.com/marcofugaro/browserslist-to-esbuild/blob/0875f1a4ec71f206a634ba406c3528ca5ecf04de/src/index.js#L79) that the older version is always last in the array that `browserslist()` returns. For Safari, `Safari TP` is last in the array.

I think [this test](https://github.com/marcofugaro/browserslist-to-esbuild/blob/0875f1a4ec71f206a634ba406c3528ca5ecf04de/test/test.js#L105) should be removed. I don't see why anyone would care about Safari TP in a browserslist query. Maybe I'm missing something?
Safari TP is already handled by [this line](https://github.com/marcofugaro/browserslist-to-esbuild/blob/0875f1a4ec71f206a634ba406c3528ca5ecf04de/src/index.js#L76).