### PR TITLE
feat: add support for with only options argument

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,4 +5,8 @@ declare function browserslistToEsbuild(
   options?: browserslist.Options
 ): string[]
 
+declare function browserslistToEsbuild(
+  options?: browserslist.Options
+): string[]
+
 export default browserslistToEsbuild

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,16 @@ import browserslist from 'browserslist'
 
 // convert the browserslist field in package.json to
 // esbuild compatible array of browsers
-export default function browserslistToEsbuild(browserslistConfig, options = {}) {
+export default function browserslistToEsbuild(browserslistConfig, options) {
+  if (
+    options === undefined &&
+    typeof browserslistConfig === 'object' &&
+    !Array.isArray(browserslistConfig)
+  ) {
+    options = browserslistConfig
+    browserslistConfig = undefined
+  }
+
   if (!browserslistConfig) {
     // the path from where the script is run
     const path = process.cwd()

--- a/test/test.js
+++ b/test/test.js
@@ -84,6 +84,18 @@ test('the options argument works', (t) => {
   cwdStub.restore()
 })
 
+test('works with only options', (t) => {
+  const browserslistrcDir = path.resolve(__dirname, './fixtures/browserslistrc')
+
+  // makes process.cwd() use that folder
+  if (!t.context.cwd) t.context.cwd = sinon.stub(process, 'cwd')
+  const cwdStub = t.context.cwd.returns(browserslistrcDir)
+
+  t.deepEqual(browserslistToEsbuild({ env: 'ssr' }), ['node12.22'])
+
+  cwdStub.restore()
+})
+
 test('works with ios', (t) => {
   const target = browserslistToEsbuild('ios >= 9')
 


### PR DESCRIPTION
Original function requires `browserslistConfig` to be undefined when we only want to set options. It's a bit ugly. This change allows to set only `options`.